### PR TITLE
fix: add id to html, store tokens in mem, adjustable callback scheme 

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -63,11 +63,11 @@ func indexHandler(res http.ResponseWriter, req *http.Request) {
 		"<p>Authentication Context Class Reference: <span id=\"oidc-auth-ctx-class-ref\">%s</span></p>"+
 		"<p>Authentication Methods Reference: <span id=\"oidc-auth-method-ref\">%s</span></p>"+
 		"<p>Audience: <span id=\"oidc-audience\">%s</span></p>"+
-		"<p>Expires: <span id=\"oidc-expires\">%d</span></p>"+
-		"<p>Issue Time: <span id=\"oidc-issue-time\">%d</span></p>"+
-		"<p>Requested At: <span id=\"requested-at\">%d</span></p>"+
-		"<p>Authorize Time: <span id=\"oidc-auth-at\">%d</span></p>"+
-		"<p>Not Before: <span id=\"oidc-not-before\">%d</span></p>"+
+		"<p>Expires: <span id=\"oidc-expires\">%f</span></p>"+
+		"<p>Issue Time: <span id=\"oidc-issue-time\">%f</span></p>"+
+		"<p>Requested At: <span id=\"requested-at\">%f</span></p>"+
+		"<p>Authorize Time: <span id=\"oidc-auth-at\">%f</span></p>"+
+		"<p>Not Before: <span id=\"oidc-not-before\">%f</span></p>"+
 		"<p>Issuer: <span id=\"oidc-issuer\">%s</span></p>"+
 		"<p>JWT ID: <span id=\"oidc-jwt-id\">%s</span></p>"+
 		"<p>Subject: <span id=\"oidc-subj\">%s</span></p>"+

--- a/handlers.go
+++ b/handlers.go
@@ -37,7 +37,7 @@ func indexHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if logged, ok := session.Values["logged"].(bool); !ok || !logged {
-		fmt.Fprintf(res, "<p>Not logged yet...</p> <a href=\"/login\">Log in</a>")
+		fmt.Fprintf(res, "<p>Not logged yet...</p> <a id=\"login-link\" href=\"/login\">Log in</a>")
 
 		return
 	}
@@ -58,25 +58,25 @@ func indexHandler(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("Content-Type", "text/html")
 	fmt.Fprintf(res, "<p>Logged in as %s!</p>"+
 		"<p><a href=\"/logout\">Log out</a></p>"+
-		"<p>Access Token Hash: %s</p>"+
-		"<p>Code Hash: %s</p>"+
-		"<p>Authentication Context Class Reference: %s</p>"+
-		"<p>Authentication Methods Reference: %s</p>"+
-		"<p>Audience: %s</p>"+
-		"<p>Expires: %d</p>"+
-		"<p>Issue Time: %d</p>"+
-		"<p>Requested At: %d</p>"+
-		"<p>Authorize Time: %d</p>"+
-		"<p>Not Before: %d</p>"+
-		"<p>Issuer: %s</p>"+
-		"<p>JWT ID: %s</p>"+
-		"<p>Subject: %s</p>"+
-		"<p>Nonce: %s</p>"+
-		"<p>Email: %s</p>"+
-		"<p>Email Verified: %v</p>"+
-		"<p>Groups: %s</p>"+
-		"<p>Name: %s</p>"+
-		"<p>Raw: %s</p>",
+		"<p>Access Token Hash: <span id=\"oidc-access-token-hash\">%s</span></p>"+
+		"<p>Code Hash: <span id=\"oidc-code-hash\">%s</span></p>"+
+		"<p>Authentication Context Class Reference: <span id=\"oidc-auth-ctx-class-ref\">%s</span></p>"+
+		"<p>Authentication Methods Reference: <span id=\"oidc-auth-method-ref\">%s</span></p>"+
+		"<p>Audience: <span id=\"oidc-audience\">%s</span></p>"+
+		"<p>Expires: <span id=\"oidc-expires\">%d</span></p>"+
+		"<p>Issue Time: <span id=\"oidc-issue-time\">%d</span></p>"+
+		"<p>Requested At: <span id=\"requested-at\">%d</span></p>"+
+		"<p>Authorize Time: <span id=\"oidc-auth-at\">%d</span></p>"+
+		"<p>Not Before: <span id=\"oidc-not-before\">%d</span></p>"+
+		"<p>Issuer: <span id=\"oidc-issuer\">%s</span></p>"+
+		"<p>JWT ID: <span id=\"oidc-jwt-id\">%s</span></p>"+
+		"<p>Subject: <span id=\"oidc-subj\">%s</span></p>"+
+		"<p>Nonce: <span id=\"oidc-nonce\">%s</span></p>"+
+		"<p>Email: <span id=\"oidc-email\">%s</span></p>"+
+		"<p>Email Verified: <span id=\"oidc-email-verified\">%v</span></p>"+
+		"<p>Groups: <span id=\"oidc-groups\">%s</span></p>"+
+		"<p>Name: <span id=\"oidc-name\">%s</span></p>"+
+		"<p>Raw: <span id=\"oidc-raw\">%s</span></p>",
 		filterText(claims.Subject, options.Filters),
 		claims.AccessTokenHash,
 		claims.CodeHash,
@@ -96,7 +96,7 @@ func indexHandler(res http.ResponseWriter, req *http.Request) {
 		claims.EmailVerified,
 		strings.Join(groups, ", "),
 		filterText(claims.Name, options.Filters),
-		session.Values["idToken"],
+		rawTokens[claims.JWTIdentifier],
 	)
 }
 
@@ -124,7 +124,7 @@ func protectedBasicHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	res.Header().Add("Content-Type", "text/html")
-	fmt.Fprintf(res, "<p>This is the protected endpoint</p>"+
+	fmt.Fprintf(res, "<p id=\"message\">This is the protected endpoint</p>"+
 		"<p id=\"protected-secret\">2511140547</p>")
 }
 
@@ -158,35 +158,35 @@ func protectedAdvancedHandler(res http.ResponseWriter, req *http.Request) {
 
 	if vars["type"] == "user" {
 		if strings.EqualFold(vars["user"], claims.Subject) {
-			fmt.Fprintf(res, "<p>This is the protected user endpoint</p>"+
-				"<p id=\"message\">Access Granted. Your username is '%s'.</p>"+
-				"<p id=\"access\">1</p>", vars["user"])
+			fmt.Fprintf(res, "<p id=\"message\">This is the protected user endpoint</p>"+
+				"<p id=\"message-grant\">Access Granted. Your username is '<span id=\"user\">%s</span>'.</p>"+
+				"<p id=\"access-granted\">1</p>", vars["user"])
 
 			return
 		}
-		fmt.Fprintf(res, "<p>This is the protected user endpoint</p>"+
-			"<p id=\"message\">Access Denied. Requires user '%s'.</p>"+
-			"<p id=\"access\">0</p>", vars["user"])
+		fmt.Fprintf(res, "<p id=\"message\">This is the protected user endpoint</p>"+
+			"<p id=\"grant-message\">Access Denied. Requires user '<span id=\"user\">%s</span>'.</p>"+
+			"<p id=\"access-granted\">0</p>", vars["user"])
 
 		return
 	}
 
 	if vars["type"] != "group" {
-		fmt.Fprintf(res, "<p>This is the protected invalid endpoint</p>")
+		fmt.Fprintf(res, "<p id=\"message\">This is the protected invalid endpoint</p>")
 
 		return
 	}
 
 	if isStringInSlice(vars["group"], claims.Groups) {
-		fmt.Fprintf(res, "<p>This is the protected group endpoint</p>"+
-			"<p id=\"message\">Access Granted. You have the group '%s'.</p>"+
-			"<p id=\"access\">1</p>", vars["group"])
+		fmt.Fprintf(res, "<p id=\"message\">This is the protected group endpoint</p>"+
+			"<p id=\"grant-message\">Access Granted. You have the group '<span id=\"group\">%s</span>'.</p>"+
+			"<p id=\"access-granted\">1</p>", vars["group"])
 
 		return
 	}
-	fmt.Fprintf(res, "<p>This is the protected group endpoint</p>"+
-		"<p id=\"message\">Access Denied. Requires group '%s'.</p>"+
-		"<p id=\"access\">0</p>", vars["group"])
+	fmt.Fprintf(res, "<p id=\"message\">This is the protected group endpoint</p>"+
+		"<p id=\"grant-message\">Access Denied. Requires group '<span id=\"group\">%s</span>'.</p>"+
+		"<p id=\"access-granted\">0</p>", vars["group"])
 }
 
 func loginHandler(res http.ResponseWriter, req *http.Request) {
@@ -278,7 +278,7 @@ func oauthCallbackHandler(res http.ResponseWriter, req *http.Request) {
 
 	session.Values["claims"] = claims
 	session.Values["logged"] = true
-	session.Values["idToken"] = rawIDToken
+	rawTokens[claims.JWTIdentifier] = rawIDToken
 
 	if err = session.Save(req, res); err != nil {
 		fmt.Println(err.Error())

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ var store = sessions.NewCookieStore([]byte("secret-key"))
 
 var oauth2Config oauth2.Config
 
+var rawTokens = make(map[string]string)
+
 func main() {
 	gob.Register(Claims{})
 
@@ -33,6 +35,7 @@ func main() {
 
 	rootCmd.Flags().StringVar(&options.Host, "host", "0.0.0.0", "Specifies the host to listen on")
 	rootCmd.Flags().IntVar(&options.Port, "port", 8080, "Specifies the port to listen on")
+	rootCmd.Flags().StringVar(&options.RedirectScheme, "redirect-scheme", "https", "Specifies the scheme used to generate the RedirectURL")
 	rootCmd.Flags().StringVarP(&options.RedirectDomain, "redirect-domain", "d", "localhost", "Specifies the domain used to generate the RedirectURL")
 	rootCmd.Flags().StringVar(&options.ClientID, "id", "", "Specifies the OpenID Connect Client ID")
 	rootCmd.Flags().StringVarP(&options.ClientSecret, "secret", "s", "", "Specifies the OpenID Connect Client Secret")
@@ -53,7 +56,7 @@ func main() {
 }
 
 func root(cmd *cobra.Command, args []string) {
-	options.RedirectURL = fmt.Sprintf("https://%s:%d/oauth2/callback", options.RedirectDomain, options.Port)
+	options.RedirectURL = fmt.Sprintf("%s://%s:%d/oauth2/callback", options.RedirectScheme, options.RedirectDomain, options.Port)
 
 	fmt.Printf("Provider URL: %s.\nRedirect URL: %s.\n", options.Issuer, options.RedirectURL)
 

--- a/types.go
+++ b/types.go
@@ -6,11 +6,11 @@ type Claims struct {
 	AuthenticationContextClassReference string   `json:"acr"`
 	AuthenticationMethodsReference      string   `json:"amr"`
 	Audience                            []string `json:"aud"`
-	Expires                             int      `json:"exp"`
-	IssueTime                           int      `json:"iat"`
-	RequestedAt                         int      `json:"rat"`
-	AuthorizeTime                       int      `json:"auth_time"`
-	NotBefore                           int      `json:"nbf"`
+	Expires                             float64  `json:"exp"`
+	IssueTime                           float64  `json:"iat"`
+	RequestedAt                         float64  `json:"rat"`
+	AuthorizeTime                       float64  `json:"auth_time"`
+	NotBefore                           float64  `json:"nbf"`
 	Issuer                              string   `json:"iss"`
 	Scope                               []string `json:"scp"`
 	ScopeString                         string   `json:"scope"`

--- a/types.go
+++ b/types.go
@@ -29,6 +29,7 @@ type Options struct {
 	ClientID       string
 	ClientSecret   string
 	Issuer         string
+	RedirectScheme string
 	RedirectURL    string
 	RedirectDomain string
 	Scopes         string


### PR DESCRIPTION
This adds uniform id's to many fields to make it easier to select them in integration testing. Additionally it allows changing the scheme from the default of https. Lastly it removes the encoded id token storage in the session which could cause a too long error with the cookie.