### PR TITLE
refactor: simplify parsing public url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,21 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/spf13/cobra v1.3.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -759,6 +761,7 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/types.go
+++ b/types.go
@@ -1,9 +1,5 @@
 package main
 
-import (
-	"net/url"
-)
-
 type Claims struct {
 	AccessTokenHash                     string   `json:"at_hash"`
 	CodeHash                            string   `json:"c_hash"`
@@ -28,16 +24,14 @@ type Claims struct {
 }
 
 type Options struct {
-	Host            string
-	Port            int
-	ClientID        string
-	ClientSecret    string
-	Issuer          string
-	PublicURL       string
-	ParsedPublicURL url.URL
-	RedirectURL     string
-	Scopes          string
-	CookieName      string
-	Filters         []string
-	GroupsFilter    []string
+	Host         string
+	Port         int
+	ClientID     string
+	ClientSecret string
+	Issuer       string
+	PublicURL    string
+	Scopes       string
+	CookieName   string
+	Filters      []string
+	GroupsFilter []string
 }

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"net/url"
+	"path"
 	"strings"
 )
 
@@ -32,4 +35,24 @@ func filterSliceOfText(input []string, filters []string) (output []string) {
 	}
 
 	return output
+}
+
+func getURLs(rootURL string) (publicURL *url.URL, redirectURL *url.URL, err error) {
+	if publicURL, err = url.Parse(rootURL); err != nil {
+		return nil, nil, err
+	}
+
+	if publicURL.Scheme != "http" && publicURL.Scheme != "https" {
+		return nil, nil, fmt.Errorf("scheme must be http or https but it is '%s'", publicURL.Scheme)
+	}
+
+	if !strings.HasSuffix(publicURL.Path, "/") {
+		publicURL.Path += "/"
+	}
+
+	redirectURL = &url.URL{}
+	*redirectURL = *publicURL
+	redirectURL.Path = path.Join(redirectURL.Path, "/oauth2/callback")
+
+	return publicURL, redirectURL, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetURLs(t *testing.T) {
+	var (
+		public, redirect *url.URL
+		err              error
+	)
+
+	public, redirect, err = getURLs("https://app.example.com")
+
+	assert.NoError(t, err)
+	require.NotNil(t, public)
+	require.NotNil(t, redirect)
+
+	assert.Equal(t, "https://app.example.com/", public.String())
+	assert.Equal(t, "https://app.example.com/oauth2/callback", redirect.String())
+
+	public, redirect, err = getURLs("https://app.example.com/")
+
+	assert.NoError(t, err)
+	require.NotNil(t, public)
+	require.NotNil(t, redirect)
+
+	assert.Equal(t, "https://app.example.com/", public.String())
+	assert.Equal(t, "https://app.example.com/oauth2/callback", redirect.String())
+
+	public, redirect, err = getURLs("https://app.example.com:5050/")
+
+	assert.NoError(t, err)
+	require.NotNil(t, public)
+	require.NotNil(t, redirect)
+
+	assert.Equal(t, "https://app.example.com:5050/", public.String())
+	assert.Equal(t, "https://app.example.com:5050/oauth2/callback", redirect.String())
+
+	public, redirect, err = getURLs("app.example.com")
+
+	assert.EqualError(t, err, "scheme must be http or https but it is ''")
+	assert.Nil(t, public)
+	assert.Nil(t, redirect)
+}


### PR DESCRIPTION
This makes the parsed URL's local variables instead of options variables, and adds a testable method to obtain them.